### PR TITLE
Change scope to provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Add "akka-http-oauth2-provider" to library dependencies of your project.
 
 ```scala
 libraryDependencies ++= Seq(
+  "com.nulab-inc" %% "scala-oauth2-provider" % "1.2.0",
   "com.nulab-inc" %% "akka-http-oauth2-provider" % "1.2.0"
 )
 ```

--- a/buid.sbt
+++ b/buid.sbt
@@ -44,7 +44,7 @@ lazy val root = Project(
     version := "1.2.1-SNAPSHOT",
     resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/maven-releases/",
     libraryDependencies ++= Seq(
-      "com.nulab-inc" % "scala-oauth2-core_2.11" % "1.2.0",
+      "com.nulab-inc" % "scala-oauth2-core_2.11" % "1.2.0" % "provided",
       "com.typesafe.akka" %% "akka-http-experimental" % akkaVersion,
       "com.typesafe.akka" %% "akka-http-core" % akkaVersion,
       "com.typesafe.akka" %% "akka-http-testkit" % akkaVersion,


### PR DESCRIPTION
Separated project from scala-oauth2-provider, so release version also will be different between core and Akka HTTP module. This PR changes scope of `libraryDependencies` for scala-oauth2-provider.